### PR TITLE
Add agent chat lifecycle tools

### DIFF
--- a/__tests__/delegation-planner.test.ts
+++ b/__tests__/delegation-planner.test.ts
@@ -23,6 +23,10 @@ describe('registryBroker.delegate tool', () => {
       agenticSearch: vi.fn(),
       delegate,
       sendMessage: vi.fn(),
+      checkChatReadiness: vi.fn(),
+      retryMessage: vi.fn(),
+      cancelSession: vi.fn(),
+      endSession: vi.fn(),
       getHistory: vi.fn(),
       resolveUaid: vi.fn(),
     }).find((entry) => entry.name === 'registryBroker.delegate');
@@ -88,6 +92,10 @@ describe('registryBroker.delegate tool', () => {
       agenticSearch: vi.fn(),
       delegate,
       sendMessage: vi.fn(),
+      checkChatReadiness: vi.fn(),
+      retryMessage: vi.fn(),
+      cancelSession: vi.fn(),
+      endSession: vi.fn(),
       getHistory: vi.fn(),
       resolveUaid: vi.fn(),
     }).find((entry) => entry.name === 'registryBroker.delegate');
@@ -160,6 +168,10 @@ describe('registryBroker.delegate tool', () => {
       agenticSearch: vi.fn(),
       delegate,
       sendMessage: vi.fn(),
+      checkChatReadiness: vi.fn(),
+      retryMessage: vi.fn(),
+      cancelSession: vi.fn(),
+      endSession: vi.fn(),
       getHistory: vi.fn(),
       resolveUaid: vi.fn(),
     }).find((entry) => entry.name === 'registryBroker.delegate');

--- a/__tests__/mcp.test.ts
+++ b/__tests__/mcp.test.ts
@@ -82,6 +82,24 @@ function createService() {
     sendMessage: vi.fn().mockResolvedValue({
       sessionId: 'session-1',
       message: 'delegated answer',
+      deliveryState: 'responded',
+    }),
+    checkChatReadiness: vi.fn().mockResolvedValue({
+      status: 'responsive',
+      routeType: 'a2a',
+    }),
+    retryMessage: vi.fn().mockResolvedValue({
+      sessionId: 'session-1',
+      message: 'delegated answer',
+      idempotent: true,
+    }),
+    cancelSession: vi.fn().mockResolvedValue({
+      sessionId: 'session-1',
+      state: 'ended',
+    }),
+    endSession: vi.fn().mockResolvedValue({
+      sessionId: 'session-1',
+      state: 'ended',
     }),
     getHistory: vi.fn().mockResolvedValue({
       sessionId: 'session-1',
@@ -288,6 +306,68 @@ describe('registry broker mcp tools', () => {
     expect(service.agenticSearch).not.toHaveBeenCalled();
     expect(service.search).not.toHaveBeenCalled();
     expect(service.sendMessage).toHaveBeenCalledOnce();
+  });
+
+  it('sends a direct agent URL through summonAgent without discovery', async () => {
+    const service = createService();
+    const tool = createToolDefinitions(service).find(
+      (entry) => entry.name === 'registryBroker.summonAgent',
+    );
+
+    expect(tool).toBeDefined();
+
+    const result = await tool!.execute({
+      task: 'Ask a direct Docker agent.',
+      agentUrl: 'http://ping-agent:8080/a2a',
+      mode: 'best-match',
+      limit: 1,
+      message: 'ping',
+    });
+
+    const payload = extractToolPayload(result, 'registryBroker.summonAgent');
+    expect(payload.strategy).toBe('direct-agent-url');
+    expect(service.delegate).not.toHaveBeenCalled();
+    expect(service.agenticSearch).not.toHaveBeenCalled();
+    expect(service.search).not.toHaveBeenCalled();
+    expect(service.sendMessage).toHaveBeenCalledWith({
+      agentUrl: 'http://ping-agent:8080/a2a',
+      message: 'ping',
+      streaming: undefined,
+    });
+  });
+
+  it('exposes chat readiness, retry, cancel, and end lifecycle tools', async () => {
+    const service = createService();
+    const tools = createToolDefinitions(service);
+    const readiness = tools.find((entry) => entry.name === 'registryBroker.chatReadiness');
+    const retry = tools.find((entry) => entry.name === 'registryBroker.retryMessage');
+    const cancel = tools.find((entry) => entry.name === 'registryBroker.cancelSession');
+    const end = tools.find((entry) => entry.name === 'registryBroker.endSession');
+
+    expect(readiness).toBeDefined();
+    expect(retry).toBeDefined();
+    expect(cancel).toBeDefined();
+    expect(end).toBeDefined();
+
+    await readiness!.execute({ uaid: 'uaid:test-agent' });
+    await retry!.execute({
+      messageId: 'idem-1',
+      sessionId: 'session-1',
+      message: 'hello',
+    });
+    await cancel!.execute({ sessionId: 'session-1' });
+    await end!.execute({ sessionId: 'session-1' });
+
+    expect(service.checkChatReadiness).toHaveBeenCalledWith({ uaid: 'uaid:test-agent' });
+    expect(service.retryMessage).toHaveBeenCalledWith('idem-1', {
+      sessionId: 'session-1',
+      message: 'hello',
+      uaid: undefined,
+      agentUrl: undefined,
+      idempotencyKey: undefined,
+    });
+    expect(service.cancelSession).toHaveBeenCalledWith('session-1');
+    expect(service.endSession).toHaveBeenCalledWith('session-1');
   });
 
   it('uses planner-selected candidates before local ranking in summonAgent', async () => {
@@ -812,11 +892,13 @@ describe('registry broker mcp tools', () => {
 });
 
 const extractedToolPayloadSchema = z.object({
+  strategy: z.string().optional(),
   dryRun: z.boolean().optional(),
   dispatchPlan: z
     .array(
       z.object({
         uaid: z.string().optional(),
+        agentUrl: z.string().optional(),
         message: z.string().optional(),
       }),
     )

--- a/__tests__/mcp.test.ts
+++ b/__tests__/mcp.test.ts
@@ -326,6 +326,7 @@ describe('registry broker mcp tools', () => {
 
     const payload = extractToolPayload(result, 'registryBroker.summonAgent');
     expect(payload.strategy).toBe('direct-agent-url');
+    expect(payload.candidates?.[0]?.label).toBe('Direct agent endpoint');
     expect(service.delegate).not.toHaveBeenCalled();
     expect(service.agenticSearch).not.toHaveBeenCalled();
     expect(service.search).not.toHaveBeenCalled();
@@ -894,6 +895,14 @@ describe('registry broker mcp tools', () => {
 const extractedToolPayloadSchema = z.object({
   strategy: z.string().optional(),
   dryRun: z.boolean().optional(),
+  candidates: z
+    .array(
+      z.object({
+        uaid: z.string(),
+        label: z.string(),
+      }),
+    )
+    .optional(),
   dispatchPlan: z
     .array(
       z.object({

--- a/scripts/e2e-local-broker.ts
+++ b/scripts/e2e-local-broker.ts
@@ -8,7 +8,8 @@ const projectRoot = path.resolve(__dirname, '..');
 const defaultPingAgentUaid =
   'uaid:aid:2vdWUw1Qd26QtfXomHZhSJb6x4Pd3r5MTYr82v9A15ua2ja8TiVTWZEFAg1rQ37gpW';
 const holHostedBrokerBaseUrl = 'https://hol.org/registry/api/v1';
-const brokerBaseUrl = readEnvOrDefault('REGISTRY_BROKER_API_URL', holHostedBrokerBaseUrl);
+const localBrokerBaseUrl = 'http://127.0.0.1:4000/api/v1';
+const brokerBaseUrl = readEnvOrDefault('REGISTRY_BROKER_API_URL', localBrokerBaseUrl);
 const isHolHostedBroker = brokerBaseUrl === holHostedBrokerBaseUrl;
 const brokerApiKey = readOptionalEnv('REGISTRY_BROKER_API_KEY');
 const registries = readOptionalListEnv('REGISTRY_BROKER_E2E_REGISTRIES');
@@ -41,6 +42,9 @@ const delegationPlanWorkspace = {
 const discoveryLimit = readOptionalIntEnv('REGISTRY_BROKER_E2E_DISCOVERY_LIMIT') ?? 5;
 const brokerTargetUaid =
   readOptionalEnv('REGISTRY_BROKER_E2E_UAID') ?? (!isHolHostedBroker ? defaultPingAgentUaid : undefined);
+const brokerTargetAgentUrl =
+  readOptionalEnv('REGISTRY_BROKER_E2E_AGENT_URL') ??
+  (!isHolHostedBroker ? 'http://ping-agent:8080/a2a' : undefined);
 const brokerProbeMessage = readOptionalEnv('REGISTRY_BROKER_E2E_MESSAGE') ?? 'ping';
 const brokerExpectedText = readOptionalEnv('REGISTRY_BROKER_E2E_EXPECT') ?? 'PONG';
 const querySummonQuery = readOptionalEnv('REGISTRY_BROKER_E2E_QUERY_SUMMON_QUERY');
@@ -190,17 +194,25 @@ async function runDirectBrokerVerification(
     matchedLabel?: string;
   };
   dryRun: {
-    uaid: string;
+    uaid?: string;
+    agentUrl?: string;
     nextAction?: string;
   };
   querySummon?: {
     query: string;
     sessionId: string;
   };
-  uaid: string;
+  uaid?: string;
+  agentUrl?: string;
   sessionId: string;
 }> {
-  if (!discoveryTask || !discoveryQuery || !discoveryExpectedUaid || !delegationPlanExpectedUaid || !brokerTargetUaid) {
+  if (
+    !discoveryTask ||
+    !discoveryQuery ||
+    !discoveryExpectedUaid ||
+    !delegationPlanExpectedUaid ||
+    (!brokerTargetUaid && !brokerTargetAgentUrl)
+  ) {
     throw new Error('Direct broker verification is missing required configuration.');
   }
 
@@ -289,7 +301,8 @@ async function runDirectBrokerVerification(
     name: 'registryBroker.summonAgent',
     arguments: {
       task: 'Verify broker delegation to a caller-specified target agent.',
-      uaid: brokerTargetUaid,
+      ...(brokerTargetUaid ? { uaid: brokerTargetUaid } : {}),
+      ...(brokerTargetAgentUrl ? { agentUrl: brokerTargetAgentUrl } : {}),
       dryRun: true,
       limit: 1,
       mode: 'best-match',
@@ -310,14 +323,18 @@ async function runDirectBrokerVerification(
     };
     dispatchPlan?: Array<{
       uaid?: string;
+      agentUrl?: string;
       message?: string;
     }>;
   }>(dryRunResult, 'registryBroker.summonAgent');
   if (dryRunPayload.dryRun !== true) {
     throw new Error('summonAgent dry run did not mark the payload as dryRun=true.');
   }
-  if (dryRunPayload.dispatchPlan?.[0]?.uaid !== brokerTargetUaid) {
+  if (brokerTargetUaid && dryRunPayload.dispatchPlan?.[0]?.uaid !== brokerTargetUaid) {
     throw new Error('summonAgent dry run did not preserve the direct UAID target.');
+  }
+  if (brokerTargetAgentUrl && dryRunPayload.dispatchPlan?.[0]?.agentUrl !== brokerTargetAgentUrl) {
+    throw new Error('summonAgent dry run did not preserve the direct agentUrl target.');
   }
   if (!dryRunPayload.dispatchPlan?.[0]?.message?.includes('Acceptance criteria:')) {
     throw new Error('summonAgent dry run did not render the structured brief.');
@@ -327,7 +344,8 @@ async function runDirectBrokerVerification(
     name: 'registryBroker.summonAgent',
     arguments: {
       task: 'Verify broker delegation to a caller-specified target agent.',
-      uaid: brokerTargetUaid,
+      ...(brokerTargetUaid ? { uaid: brokerTargetUaid } : {}),
+      ...(brokerTargetAgentUrl ? { agentUrl: brokerTargetAgentUrl } : {}),
       limit: 1,
       mode: 'best-match',
       message: brokerProbeMessage,
@@ -383,9 +401,11 @@ async function runDirectBrokerVerification(
       : undefined,
     dryRun: {
       uaid: brokerTargetUaid,
+      agentUrl: brokerTargetAgentUrl,
       nextAction: dryRunPayload.nextAction?.type,
     },
     uaid: brokerTargetUaid,
+    agentUrl: brokerTargetAgentUrl,
     sessionId,
   };
 }
@@ -741,7 +761,7 @@ function hasDirectBrokerVerificationConfig(): boolean {
       discoveryQuery &&
       discoveryExpectedUaid &&
       delegationPlanExpectedUaid &&
-      brokerTargetUaid,
+      (brokerTargetUaid || brokerTargetAgentUrl),
   );
 }
 

--- a/src/broker.ts
+++ b/src/broker.ts
@@ -36,6 +36,10 @@ export interface BrokerService {
     filter?: Record<string, unknown>;
   }): Promise<unknown>;
   sendMessage(input: SendMessageRequestPayload): Promise<SendMessageResponse>;
+  checkChatReadiness(input: Record<string, unknown>): Promise<unknown>;
+  retryMessage(messageId: string, input: Record<string, unknown>): Promise<unknown>;
+  cancelSession(sessionId: string): Promise<unknown>;
+  endSession(sessionId: string): Promise<unknown>;
   getHistory(sessionId: string): Promise<unknown>;
   resolveUaid(uaid: string): Promise<unknown>;
 }
@@ -126,6 +130,38 @@ export class RegistryBrokerService implements BrokerService {
 
   sendMessage(input: SendMessageRequestPayload): Promise<SendMessageResponse> {
     return this.client.chat.sendMessage(input);
+  }
+
+  checkChatReadiness(input: Record<string, unknown>): Promise<unknown> {
+    return this.client.requestJson('/chat/readiness', {
+      method: 'POST',
+      body: input,
+      headers: {
+        'content-type': 'application/json',
+      },
+    });
+  }
+
+  retryMessage(messageId: string, input: Record<string, unknown>): Promise<unknown> {
+    return this.client.requestJson(`/chat/message/${encodeURIComponent(messageId)}/retry`, {
+      method: 'POST',
+      body: input,
+      headers: {
+        'content-type': 'application/json',
+      },
+    });
+  }
+
+  cancelSession(sessionId: string): Promise<unknown> {
+    return this.client.requestJson(`/chat/session/${encodeURIComponent(sessionId)}/cancel`, {
+      method: 'POST',
+    });
+  }
+
+  endSession(sessionId: string): Promise<unknown> {
+    return this.client.requestJson(`/chat/session/${encodeURIComponent(sessionId)}`, {
+      method: 'DELETE',
+    });
   }
 
   getHistory(sessionId: string): Promise<unknown> {

--- a/src/delegation.ts
+++ b/src/delegation.ts
@@ -19,15 +19,18 @@ export type SummonExecutionInput = {
   brief: string;
   message?: string;
   streaming?: boolean;
+  agentUrl?: string;
   mode: 'best-match' | 'fallback' | 'parallel';
   limit: number;
 };
 
 export type SummonDispatchResult = {
-  uaid: string;
+  uaid?: string;
+  agentUrl?: string;
   label: string;
   message: string;
   status: 'ok' | 'error';
+  outcome?: string;
   response?: unknown;
   error?: string;
 };
@@ -117,17 +120,25 @@ export async function sendToCandidate(
 ): Promise<SummonDispatchResult> {
   const message =
     input.message ?? candidate.suggestedMessage ?? buildDelegateMessage(input.brief, candidate);
+  const messageRequest = input.agentUrl
+    ? {
+        agentUrl: input.agentUrl,
+        message,
+        streaming: input.streaming,
+      }
+    : {
+        uaid: candidate.uaid,
+        message,
+        streaming: input.streaming,
+      };
   const response = await safeInvoke(() =>
-    service.sendMessage({
-      uaid: candidate.uaid,
-      message,
-      streaming: input.streaming,
-    }),
+    service.sendMessage(messageRequest),
   );
 
   if (response.error) {
     return {
       uaid: candidate.uaid,
+      agentUrl: input.agentUrl,
       label: candidate.label,
       message,
       status: 'error',
@@ -137,11 +148,33 @@ export async function sendToCandidate(
 
   return {
     uaid: candidate.uaid,
+    agentUrl: input.agentUrl,
     label: candidate.label,
     message,
     status: 'ok',
+    outcome: describeChatOutcome(response.value),
     response: response.value,
   };
+}
+
+function describeChatOutcome(value: unknown): string {
+  if (!isJsonRecord(value)) {
+    return 'response_received';
+  }
+
+  if (value.deliveryConfirmation === true || value.replyMode === 'delivery_only') {
+    return 'delivery_confirmed';
+  }
+
+  if (value.deliveryState === 'responded' || typeof value.message === 'string') {
+    return 'assistant_response';
+  }
+
+  if (typeof value.deliveryState === 'string') {
+    return value.deliveryState;
+  }
+
+  return 'response_received';
 }
 
 export async function preferReachableCandidates(

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -442,7 +442,7 @@ export function createToolDefinitions(
         logger.info({ requestId, tool: 'registryBroker.summonAgent' }, 'tool.invoke');
 
         const directTarget = input.agentUrl
-          ? { uaid: input.uaid ?? input.agentUrl, label: input.uaid ?? input.agentUrl }
+          ? { uaid: input.uaid ?? input.agentUrl, label: input.uaid ?? 'Direct agent endpoint' }
           : undefined;
 
         const planResult = input.uaid || directTarget
@@ -586,25 +586,28 @@ export function createToolDefinitions(
           );
         }
 
-        const rankedCandidates: Array<{ uaid: string; label: string; suggestedMessage?: string }> = directTarget
-          ? [directTarget]
-            : input.uaid
-              ? [{ uaid: input.uaid, label: input.uaid }]
-              : plannerSelection && plannerSelection.candidates.length > 0 && !shouldFallbackToSearch
-                ? plannerSelection.candidates
-                : await findFallbackCandidates(service, query, {
-                    task: delegationBrief,
-                    limit: desiredCandidateCount,
-                    registries: input.registries,
-                    capabilities: input.capabilities,
-                    protocols: input.protocols,
-                    adapters: input.adapters,
-                    minTrust: input.minTrust,
-                    verified: input.verified,
-                    online: input.online,
-                    type: input.type,
-                    desiredCandidateCount,
-                  });
+        let rankedCandidates: Array<{ uaid: string; label: string; suggestedMessage?: string }>;
+        if (directTarget) {
+          rankedCandidates = [directTarget];
+        } else if (input.uaid) {
+          rankedCandidates = [{ uaid: input.uaid, label: input.uaid }];
+        } else if (plannerSelection && plannerSelection.candidates.length > 0 && !shouldFallbackToSearch) {
+          rankedCandidates = plannerSelection.candidates;
+        } else {
+          rankedCandidates = await findFallbackCandidates(service, query, {
+            task: delegationBrief,
+            limit: desiredCandidateCount,
+            registries: input.registries,
+            capabilities: input.capabilities,
+            protocols: input.protocols,
+            adapters: input.adapters,
+            minTrust: input.minTrust,
+            verified: input.verified,
+            online: input.online,
+            type: input.type,
+            desiredCandidateCount,
+          });
+        }
         const candidates = input.uaid || directTarget
           ? rankedCandidates
           : await preferReachableCandidates(

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -30,6 +30,9 @@ import {
 } from './ranking';
 import {
   delegateSchema,
+  chatEndSchema,
+  chatReadinessSchema,
+  chatRetrySchema,
   searchSchema,
   sessionHistorySchema,
   summonSchema,
@@ -73,8 +76,11 @@ export function createToolDefinitions(
 ): Array<
   ToolDefinition<
     | typeof searchSchema
-    | typeof delegateSchema
-    | typeof summonSchema
+     | typeof delegateSchema
+     | typeof chatEndSchema
+     | typeof chatReadinessSchema
+     | typeof chatRetrySchema
+     | typeof summonSchema
     | typeof sessionHistorySchema
   >
 > {
@@ -150,6 +156,107 @@ export function createToolDefinitions(
             nextAction,
             planner: result,
           },
+        );
+      },
+    },
+    {
+      name: 'registryBroker.chatReadiness',
+      description: 'Check whether a broker agent route can support chat before opening a session.',
+      parameters: chatReadinessSchema,
+      annotations: {
+        title: 'Registry Broker Chat Readiness',
+        readOnlyHint: true,
+      },
+      execute: async (args, context) => {
+        const requestId = context?.requestId ?? randomUUID();
+        const input = chatReadinessSchema.parse(args);
+        if (!input.uaid && !input.agentUrl) {
+          return resultWithPayload(
+            'Provide either uaid or agentUrl.',
+            'registryBroker.chatReadiness',
+            { error: 'uaid_or_agent_url_required' },
+          );
+        }
+
+        logger.info({ requestId, tool: 'registryBroker.chatReadiness' }, 'tool.invoke');
+        const readiness = await service.checkChatReadiness(input);
+        logger.info({ requestId, tool: 'registryBroker.chatReadiness' }, 'tool.success');
+
+        return resultWithPayload(
+          'Chat readiness checked.',
+          'registryBroker.chatReadiness',
+          { readiness },
+        );
+      },
+    },
+    {
+      name: 'registryBroker.retryMessage',
+      description: 'Retry a broker chat message by persisted message/idempotency key.',
+      parameters: chatRetrySchema,
+      annotations: {
+        title: 'Registry Broker Retry Message',
+      },
+      execute: async (args, context) => {
+        const requestId = context?.requestId ?? randomUUID();
+        const input = chatRetrySchema.parse(args);
+        logger.info({ requestId, tool: 'registryBroker.retryMessage' }, 'tool.invoke');
+        const response = await service.retryMessage(input.messageId, {
+          sessionId: input.sessionId,
+          message: input.message,
+          uaid: input.uaid,
+          agentUrl: input.agentUrl,
+          idempotencyKey: input.idempotencyKey,
+        });
+        logger.info({ requestId, tool: 'registryBroker.retryMessage' }, 'tool.success');
+
+        return resultWithPayload(
+          'Chat message retry completed.',
+          'registryBroker.retryMessage',
+          { sessionId: input.sessionId, response },
+        );
+      },
+    },
+    {
+      name: 'registryBroker.cancelSession',
+      description: 'Cancel a broker chat session and return its terminal state.',
+      parameters: chatEndSchema,
+      annotations: {
+        title: 'Registry Broker Cancel Session',
+        destructiveHint: true,
+      },
+      execute: async (args, context) => {
+        const requestId = context?.requestId ?? randomUUID();
+        const input = chatEndSchema.parse(args);
+        logger.info({ requestId, tool: 'registryBroker.cancelSession' }, 'tool.invoke');
+        const session = await service.cancelSession(input.sessionId);
+        logger.info({ requestId, tool: 'registryBroker.cancelSession' }, 'tool.success');
+
+        return resultWithPayload(
+          `Cancelled chat session ${input.sessionId}.`,
+          'registryBroker.cancelSession',
+          { session },
+        );
+      },
+    },
+    {
+      name: 'registryBroker.endSession',
+      description: 'End a broker chat session and return its terminal state.',
+      parameters: chatEndSchema,
+      annotations: {
+        title: 'Registry Broker End Session',
+        destructiveHint: true,
+      },
+      execute: async (args, context) => {
+        const requestId = context?.requestId ?? randomUUID();
+        const input = chatEndSchema.parse(args);
+        logger.info({ requestId, tool: 'registryBroker.endSession' }, 'tool.invoke');
+        const session = await service.endSession(input.sessionId);
+        logger.info({ requestId, tool: 'registryBroker.endSession' }, 'tool.success');
+
+        return resultWithPayload(
+          `Ended chat session ${input.sessionId}.`,
+          'registryBroker.endSession',
+          { session },
         );
       },
     },
@@ -334,7 +441,11 @@ export function createToolDefinitions(
 
         logger.info({ requestId, tool: 'registryBroker.summonAgent' }, 'tool.invoke');
 
-        const planResult = input.uaid
+        const directTarget = input.agentUrl
+          ? { uaid: input.uaid ?? input.agentUrl, label: input.uaid ?? input.agentUrl }
+          : undefined;
+
+        const planResult = input.uaid || directTarget
           ? undefined
           : await safeInvoke(() =>
               service.delegate({
@@ -355,7 +466,7 @@ export function createToolDefinitions(
               }),
             );
         const plannerSelection =
-          !input.uaid && planResult?.value !== undefined
+          !input.uaid && !directTarget && planResult?.value !== undefined
             ? selectPlannerCandidates(planResult.value, {
                 task: input.task,
                 query,
@@ -365,12 +476,13 @@ export function createToolDefinitions(
         const recommendationAction = readPlannerAction(plannerSelection?.recommendation);
         const shouldFallbackToSearch =
           !input.uaid &&
+          !directTarget &&
           (plannerSelection === undefined ||
             (recommendationAction === undefined && plannerSelection.candidates.length === 0) ||
             (recommendationAction === 'delegate-now' && plannerSelection.candidates.length === 0) ||
             (recommendationAction === 'review-shortlist' && plannerSelection.candidates.length === 0));
 
-        if (!input.uaid && recommendationAction === 'handle-locally') {
+        if (!input.uaid && !directTarget && recommendationAction === 'handle-locally') {
           const nextAction = buildDelegateNextAction(plannerSelection, {
             task: input.task,
             query,
@@ -414,6 +526,7 @@ export function createToolDefinitions(
 
         if (
           !input.uaid &&
+          !directTarget &&
           recommendationAction === 'review-shortlist' &&
           plannerSelection &&
           plannerSelection.candidates.length > 0
@@ -473,24 +586,26 @@ export function createToolDefinitions(
           );
         }
 
-        const rankedCandidates = input.uaid
-          ? [{ uaid: input.uaid, label: input.uaid }]
-          : plannerSelection && plannerSelection.candidates.length > 0 && !shouldFallbackToSearch
-            ? plannerSelection.candidates
-            : await findFallbackCandidates(service, query, {
-                task: delegationBrief,
-                limit: desiredCandidateCount,
-                registries: input.registries,
-                capabilities: input.capabilities,
-                protocols: input.protocols,
-                adapters: input.adapters,
-                minTrust: input.minTrust,
-                verified: input.verified,
-                online: input.online,
-                type: input.type,
-                desiredCandidateCount,
-              });
-        const candidates = input.uaid
+        const rankedCandidates: Array<{ uaid: string; label: string; suggestedMessage?: string }> = directTarget
+          ? [directTarget]
+            : input.uaid
+              ? [{ uaid: input.uaid, label: input.uaid }]
+              : plannerSelection && plannerSelection.candidates.length > 0 && !shouldFallbackToSearch
+                ? plannerSelection.candidates
+                : await findFallbackCandidates(service, query, {
+                    task: delegationBrief,
+                    limit: desiredCandidateCount,
+                    registries: input.registries,
+                    capabilities: input.capabilities,
+                    protocols: input.protocols,
+                    adapters: input.adapters,
+                    minTrust: input.minTrust,
+                    verified: input.verified,
+                    online: input.online,
+                    type: input.type,
+                    desiredCandidateCount,
+                  });
+        const candidates = input.uaid || directTarget
           ? rankedCandidates
           : await preferReachableCandidates(
               service,
@@ -537,6 +652,7 @@ export function createToolDefinitions(
           input.mode === 'best-match' ? candidates.slice(0, 1) : candidates.slice(0, input.limit);
         const dispatchPlan = chosen.map((candidate) => ({
           uaid: candidate.uaid,
+          agentUrl: input.agentUrl,
           label: candidate.label,
           message:
             input.message ??
@@ -558,7 +674,8 @@ export function createToolDefinitions(
               `Next action: ${String(nextAction.type)}`,
               'Dry run only. No broker message sent.',
               ...dispatchPlan.map(
-                (entry, index) => `${index + 1}. ${entry.label} — ${entry.uaid} (preview)`,
+                (entry, index) =>
+                  `${index + 1}. ${entry.label} — ${entry.agentUrl ?? entry.uaid} (preview)`,
               ),
             ].join('\n'),
             'registryBroker.summonAgent',
@@ -566,9 +683,11 @@ export function createToolDefinitions(
               strategy:
                 plannerSelection && plannerSelection.candidates.length > 0 && !shouldFallbackToSearch
                   ? 'broker-plan'
-                  : input.uaid
-                    ? 'direct-uaid'
-                    : 'search-fallback',
+                  : input.agentUrl
+                    ? 'direct-agent-url'
+                    : input.uaid
+                      ? 'direct-uaid'
+                      : 'search-fallback',
               query,
               task: input.task,
               delegationBrief,
@@ -598,6 +717,7 @@ export function createToolDefinitions(
                     brief: delegationBrief,
                     message: input.message,
                     streaming: input.streaming,
+                    agentUrl: input.agentUrl,
                     mode: input.mode,
                     limit: input.limit,
                   }),
@@ -608,6 +728,7 @@ export function createToolDefinitions(
                 brief: delegationBrief,
                 message: input.message,
                 streaming: input.streaming,
+                agentUrl: input.agentUrl,
                 mode: input.mode,
                 limit: input.limit,
               });
@@ -643,7 +764,7 @@ export function createToolDefinitions(
               : undefined,
             ...enlisted.map(
               (entry, index) =>
-                `${index + 1}. ${entry.label} — ${entry.uaid} (${entry.status})`,
+                `${index + 1}. ${entry.label} — ${entry.agentUrl ?? entry.uaid} (${entry.status})`,
             ),
           ]
             .filter(Boolean)
@@ -653,9 +774,11 @@ export function createToolDefinitions(
             strategy:
               plannerSelection && plannerSelection.candidates.length > 0 && !shouldFallbackToSearch
                 ? 'broker-plan'
-                : input.uaid
-                  ? 'direct-uaid'
-                  : 'search-fallback',
+                : input.agentUrl
+                  ? 'direct-agent-url'
+                  : input.uaid
+                    ? 'direct-uaid'
+                    : 'search-fallback',
             query,
             task: input.task,
             delegationBrief,

--- a/src/tool-contracts.ts
+++ b/src/tool-contracts.ts
@@ -55,6 +55,7 @@ export const summonSchema = z.object({
   query: z.string().optional(),
   opportunityId: z.string().min(1).optional(),
   uaid: z.string().min(1).optional(),
+  agentUrl: z.string().url().optional(),
   limit: z.number().int().min(1).max(3).default(3),
   mode: z.enum(['best-match', 'fallback', 'parallel']).default('fallback'),
   dryRun: z.boolean().default(false),
@@ -66,5 +67,23 @@ export const summonSchema = z.object({
 });
 
 export const sessionHistorySchema = z.object({
+  sessionId: z.string().min(1),
+});
+
+export const chatReadinessSchema = z.object({
+  uaid: z.string().min(1).optional(),
+  agentUrl: z.string().url().optional(),
+});
+
+export const chatRetrySchema = z.object({
+  messageId: z.string().min(1),
+  sessionId: z.string().min(1),
+  message: z.string().min(1),
+  uaid: z.string().min(1).optional(),
+  agentUrl: z.string().url().optional(),
+  idempotencyKey: z.string().min(1).optional(),
+});
+
+export const chatEndSchema = z.object({
   sessionId: z.string().min(1),
 });


### PR DESCRIPTION
## Shipped behavior
- Adds Registry Broker Codex plugin tools for chat readiness, retry, cancel, and end-session.
- Labels delegated outcomes as assistant-response or delivery-terminal and supports direct agent URL summons for local broker verification.
- Updates live local broker e2e to verify delegation, dry-run dispatch, summon, session history, and direct delivery against Docker services.

## Verification
- `pnpm run lint` — passed.
- `pnpm run typecheck` — passed.
- `pnpm test __tests__/mcp.test.ts __tests__/delegation-planner.test.ts --reporter=dot` — 2 files passed, 27 tests passed.
- `pnpm run build` — passed.

## Docker/local e2e
Command: `cd ../registry-broker && docker compose --profile extras up -d elasticsearch rocksdb-sidecar qdrant registry-broker ping-agent && cd ../registry-broker-codex-plugin && pnpm run e2e:broker`

Result: ok true; delegation checks covered code/business/design recommendations; direct verification found Registry Ping Agent, completed dry-run dispatch, summoned `http://ping-agent:8080/a2a`, returned a broker session id, and session history contained the delegated response.