### PR TITLE
Add agent chat resume controls

### DIFF
--- a/__tests__/delegation-planner.test.ts
+++ b/__tests__/delegation-planner.test.ts
@@ -28,6 +28,7 @@ describe('registryBroker.delegate tool', () => {
       cancelSession: vi.fn(),
       endSession: vi.fn(),
       getHistory: vi.fn(),
+      resumeSession: vi.fn(),
       resolveUaid: vi.fn(),
     }).find((entry) => entry.name === 'registryBroker.delegate');
 
@@ -97,6 +98,7 @@ describe('registryBroker.delegate tool', () => {
       cancelSession: vi.fn(),
       endSession: vi.fn(),
       getHistory: vi.fn(),
+      resumeSession: vi.fn(),
       resolveUaid: vi.fn(),
     }).find((entry) => entry.name === 'registryBroker.delegate');
 
@@ -173,6 +175,7 @@ describe('registryBroker.delegate tool', () => {
       cancelSession: vi.fn(),
       endSession: vi.fn(),
       getHistory: vi.fn(),
+      resumeSession: vi.fn(),
       resolveUaid: vi.fn(),
     }).find((entry) => entry.name === 'registryBroker.delegate');
 

--- a/__tests__/mcp.test.ts
+++ b/__tests__/mcp.test.ts
@@ -105,6 +105,11 @@ function createService() {
       sessionId: 'session-1',
       history: [],
     }),
+    resumeSession: vi.fn().mockResolvedValue({
+      sessionId: 'session-1',
+      history: [],
+      transport: 'a2a',
+    }),
     resolveUaid: vi.fn().mockResolvedValue({}),
   };
 }
@@ -337,29 +342,35 @@ describe('registry broker mcp tools', () => {
     });
   });
 
-  it('exposes chat readiness, retry, cancel, and end lifecycle tools', async () => {
+  it('exposes chat readiness, retry, resume, cancel, and end lifecycle tools', async () => {
     const service = createService();
     const tools = createToolDefinitions(service);
     const readiness = tools.find((entry) => entry.name === 'registryBroker.chatReadiness');
     const retry = tools.find((entry) => entry.name === 'registryBroker.retryMessage');
+    const resume = tools.find((entry) => entry.name === 'registryBroker.resumeSession');
     const cancel = tools.find((entry) => entry.name === 'registryBroker.cancelSession');
     const end = tools.find((entry) => entry.name === 'registryBroker.endSession');
 
     expect(readiness).toBeDefined();
     expect(retry).toBeDefined();
+    expect(resume).toBeDefined();
     expect(cancel).toBeDefined();
     expect(end).toBeDefined();
 
-    await readiness!.execute({ uaid: 'uaid:test-agent' });
+    await readiness!.execute({ uaid: 'uaid:test-agent', forceRefresh: true });
     await retry!.execute({
       messageId: 'idem-1',
       sessionId: 'session-1',
       message: 'hello',
     });
+    await resume!.execute({ sessionId: 'session-1' });
     await cancel!.execute({ sessionId: 'session-1' });
     await end!.execute({ sessionId: 'session-1' });
 
-    expect(service.checkChatReadiness).toHaveBeenCalledWith({ uaid: 'uaid:test-agent' });
+    expect(service.checkChatReadiness).toHaveBeenCalledWith({
+      uaid: 'uaid:test-agent',
+      forceRefresh: true,
+    });
     expect(service.retryMessage).toHaveBeenCalledWith('idem-1', {
       sessionId: 'session-1',
       message: 'hello',
@@ -367,6 +378,7 @@ describe('registry broker mcp tools', () => {
       agentUrl: undefined,
       idempotencyKey: undefined,
     });
+    expect(service.resumeSession).toHaveBeenCalledWith('session-1');
     expect(service.cancelSession).toHaveBeenCalledWith('session-1');
     expect(service.endSession).toHaveBeenCalledWith('session-1');
   });

--- a/scripts/e2e-local-broker.ts
+++ b/scripts/e2e-local-broker.ts
@@ -205,6 +205,9 @@ async function runDirectBrokerVerification(
   uaid?: string;
   agentUrl?: string;
   sessionId: string;
+  resume: {
+    sessionId: string;
+  };
 }> {
   if (
     !discoveryTask ||
@@ -349,6 +352,7 @@ async function runDirectBrokerVerification(
       limit: 1,
       mode: 'best-match',
       message: brokerProbeMessage,
+      idempotencyKey: `plugin-e2e-${Date.now()}`,
     },
   });
   assertContent(
@@ -380,6 +384,17 @@ async function runDirectBrokerVerification(
     brokerExpectedText,
     'sessionHistory did not include the expected delegated response',
   );
+  const resumeResult = await client.callTool({
+    name: 'registryBroker.resumeSession',
+    arguments: {
+      sessionId,
+    },
+  });
+  assertContent(
+    resumeResult,
+    sessionId,
+    'resumeSession did not return the expected sessionId',
+  );
 
   return {
     delegationPlan: {
@@ -407,6 +422,9 @@ async function runDirectBrokerVerification(
     uaid: brokerTargetUaid,
     agentUrl: brokerTargetAgentUrl,
     sessionId,
+    resume: {
+      sessionId,
+    },
   };
 }
 

--- a/src/broker.ts
+++ b/src/broker.ts
@@ -41,6 +41,7 @@ export interface BrokerService {
   cancelSession(sessionId: string): Promise<unknown>;
   endSession(sessionId: string): Promise<unknown>;
   getHistory(sessionId: string): Promise<unknown>;
+  resumeSession(sessionId: string): Promise<unknown>;
   resolveUaid(uaid: string): Promise<unknown>;
 }
 
@@ -166,6 +167,12 @@ export class RegistryBrokerService implements BrokerService {
 
   getHistory(sessionId: string): Promise<unknown> {
     return this.client.chat.getHistory(sessionId);
+  }
+
+  resumeSession(sessionId: string): Promise<unknown> {
+    return this.client.requestJson(`/chat/session/${encodeURIComponent(sessionId)}/resume`, {
+      method: 'GET',
+    });
   }
 
   resolveUaid(uaid: string): Promise<unknown> {

--- a/src/delegation.ts
+++ b/src/delegation.ts
@@ -19,6 +19,7 @@ export type SummonExecutionInput = {
   brief: string;
   message?: string;
   streaming?: boolean;
+  idempotencyKey?: string;
   agentUrl?: string;
   mode: 'best-match' | 'fallback' | 'parallel';
   limit: number;
@@ -125,11 +126,13 @@ export async function sendToCandidate(
         agentUrl: input.agentUrl,
         message,
         streaming: input.streaming,
+        ...(input.idempotencyKey ? { idempotencyKey: input.idempotencyKey } : {}),
       }
     : {
         uaid: candidate.uaid,
         message,
         streaming: input.streaming,
+        ...(input.idempotencyKey ? { idempotencyKey: input.idempotencyKey } : {}),
       };
   const response = await safeInvoke(() =>
     service.sendMessage(messageRequest),

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -35,6 +35,7 @@ import {
   chatRetrySchema,
   searchSchema,
   sessionHistorySchema,
+  sessionResumeSchema,
   summonSchema,
 } from './tool-contracts';
 import {
@@ -81,6 +82,7 @@ export function createToolDefinitions(
      | typeof chatReadinessSchema
      | typeof chatRetrySchema
      | typeof summonSchema
+     | typeof sessionResumeSchema
     | typeof sessionHistorySchema
   >
 > {
@@ -720,6 +722,7 @@ export function createToolDefinitions(
                     brief: delegationBrief,
                     message: input.message,
                     streaming: input.streaming,
+                    idempotencyKey: input.idempotencyKey,
                     agentUrl: input.agentUrl,
                     mode: input.mode,
                     limit: input.limit,
@@ -731,6 +734,7 @@ export function createToolDefinitions(
                 brief: delegationBrief,
                 message: input.message,
                 streaming: input.streaming,
+                idempotencyKey: input.idempotencyKey,
                 agentUrl: input.agentUrl,
                 mode: input.mode,
                 limit: input.limit,
@@ -798,6 +802,31 @@ export function createToolDefinitions(
                 ? { error: planResult.error }
                 : planResult.value
               : undefined,
+          },
+        );
+      },
+    },
+    {
+      name: 'registryBroker.resumeSession',
+      description: 'Resume a broker chat session and return its route plus history snapshot.',
+      parameters: sessionResumeSchema,
+      annotations: {
+        title: 'Registry Broker Resume Session',
+        readOnlyHint: true,
+      },
+      execute: async (args, context) => {
+        const requestId = context?.requestId ?? randomUUID();
+        const input = sessionResumeSchema.parse(args);
+        logger.info({ requestId, tool: 'registryBroker.resumeSession' }, 'tool.invoke');
+        const session = await service.resumeSession(input.sessionId);
+        logger.info({ requestId, tool: 'registryBroker.resumeSession' }, 'tool.success');
+
+        return resultWithPayload(
+          `Resumed session ${input.sessionId}.`,
+          'registryBroker.resumeSession',
+          {
+            sessionId: input.sessionId,
+            session,
           },
         );
       },

--- a/src/tool-contracts.ts
+++ b/src/tool-contracts.ts
@@ -61,6 +61,7 @@ export const summonSchema = z.object({
   dryRun: z.boolean().default(false),
   message: z.string().min(1).optional(),
   streaming: z.boolean().optional(),
+  idempotencyKey: z.string().min(1).optional(),
   ...filterFields,
   ...delegationBriefFieldsSchema.shape,
   workspace: workspaceContextSchema,
@@ -70,9 +71,14 @@ export const sessionHistorySchema = z.object({
   sessionId: z.string().min(1),
 });
 
+export const sessionResumeSchema = z.object({
+  sessionId: z.string().min(1),
+});
+
 export const chatReadinessSchema = z.object({
   uaid: z.string().min(1).optional(),
   agentUrl: z.string().url().optional(),
+  forceRefresh: z.boolean().optional(),
 });
 
 export const chatRetrySchema = z.object({


### PR DESCRIPTION
## Shipped behavior
- Adds `registryBroker.resumeSession` for restoring a delegated chat session.
- Allows summon flows to pass message idempotency keys.
- Extends local broker e2e to verify delegated summon, history, and resume against the live Docker broker.

## Verification
- `pnpm run typecheck` -> passed.
- `pnpm run lint` -> passed.
- `pnpm run build` -> build success.
- `pnpm test -- __tests__/mcp.test.ts __tests__/delegation-planner.test.ts` -> 6 files passed, 36 tests passed.
- `pnpm run e2e:broker` -> ok true, delegationConsumption code/business/design passed, directVerification matched Registry Ping Agent, summon returned sessionId, resume returned same sessionId.
- Shared no-mock Docker stack: `docker compose --profile extras up -d elasticsearch rocksdb-sidecar qdrant registry-broker ping-agent && pnpm run e2e:agent-chat` -> registration 200, readiness responsive/a2a, session idempotency true, send assistant_response, history user+agent, resume entries 2, retry responded, duplicate end ended.